### PR TITLE
Feat: expose tilt and wobble parameters for animation control

### DIFF
--- a/src/confetti.js
+++ b/src/confetti.js
@@ -246,7 +246,12 @@
     ],
     // probably should be true, but back-compat
     disableForReducedMotion: false,
-    scalar: 1
+    scalar: 1,
+    /* New feature 3-D wobble/tilt control  */
+    tiltRange:  [-Math.PI * 0.5,  Math.PI * 0.5], // [min,max] radians
+    tiltSpeed:  [0.05, 0.40],                     // radians per frame
+    wobbleRange:[0,10],                           // “radius” units
+    wobbleSpeed:[0.05,0.11]                       // per-frame
   };
 
   function convert(val, transform) {
@@ -342,8 +347,13 @@
     return {
       x: opts.x,
       y: opts.y,
-      wobble: Math.random() * 10,
-      wobbleSpeed: Math.min(0.11, Math.random() * 0.1 + 0.05),
+      //New 3-D wobble/tilt control
+      wobble:      Math.random() * (opts.wobbleRange[1] - opts.wobbleRange[0]) + opts.wobbleRange[0],
+      wobbleSpeed: Math.random() * (opts.wobbleSpeed[1] - opts.wobbleSpeed[0]) + opts.wobbleSpeed[0],
+      tiltAngle:   Math.random() * (opts.tiltRange[1] - opts.tiltRange[0])   + opts.tiltRange[0],
+      tiltIncrement: Math.random() * (opts.tiltSpeed[1] - opts.tiltSpeed[0]) + opts.tiltSpeed[0],
+      //wobble: Math.random() * 10,
+      //wobbleSpeed: Math.min(0.11, Math.random() * 0.1 + 0.05),
       velocity: (opts.startVelocity * 0.5) + (Math.random() * opts.startVelocity),
       angle2D: -radAngle + ((0.5 * radSpread) - (Math.random() * radSpread)),
       tiltAngle: (Math.random() * (0.75 - 0.25) + 0.25) * Math.PI,
@@ -378,12 +388,15 @@
       fetti.tiltSin = 0;
       fetti.tiltCos = 0;
       fetti.random = 1;
+      // New 3-d wobble/tilt control
+      fetti.tiltIncrement = 0;
     } else {
       fetti.wobble += fetti.wobbleSpeed;
       fetti.wobbleX = fetti.x + ((10 * fetti.scalar) * Math.cos(fetti.wobble));
       fetti.wobbleY = fetti.y + ((10 * fetti.scalar) * Math.sin(fetti.wobble));
 
-      fetti.tiltAngle += 0.1;
+      //fetti.tiltAngle += 0.1;
+      fetti.tiltAngle += (fetti.tiltIncrement || 0.1);
       fetti.tiltSin = Math.sin(fetti.tiltAngle);
       fetti.tiltCos = Math.cos(fetti.tiltAngle);
       fetti.random = Math.random() + 2;
@@ -569,6 +582,13 @@
       var shapes = prop(options, 'shapes');
       var scalar = prop(options, 'scalar');
       var flat = !!prop(options, 'flat');
+
+      // NEW 3-D wobble/tilt control
+      var tiltRange   = prop(options, 'tiltRange');
+      var tiltSpeed   = prop(options, 'tiltSpeed');
+      var wobbleRange = prop(options, 'wobbleRange');
+      var wobbleSpeed = prop(options, 'wobbleSpeed');
+
       var origin = getOrigin(options);
 
       var temp = particleCount;
@@ -592,7 +612,12 @@
             gravity: gravity,
             drift: drift,
             scalar: scalar,
-            flat: flat
+            flat: flat,
+            // NEW 3-D wobble/tilt control
+            tiltRange:   tiltRange,
+            tiltSpeed:   tiltSpeed,
+            wobbleRange: wobbleRange,
+            wobbleSpeed: wobbleSpeed
           })
         );
       }


### PR DESCRIPTION
This PR adds support for four new animation parameters — tiltRange, tiltSpeed, wobbleRange, and wobbleSpeed — allowing finer control over confetti particle dynamics.

These parameters enable users to adjust:
**Initial tilt angle** (tiltRange: radians)
**Tilt speed over time** (tiltSpeed)
**Wobble radius** (wobbleRange)
**Wobble speed** (wobbleSpeed)

This preserves full backward compatibility — default values match existing behavior, and the flat: true flag still overrides all 3D motion.

Example usage:
confetti({
  particleCount: 40,
  tiltRange: [-Math.PI / 4, Math.PI / 4],
  tiltSpeed: [0.05, 0.1],
  wobbleRange: [3, 8],
  wobbleSpeed: [0.05, 0.15]
});
